### PR TITLE
替换 `uuid` 为更轻量更快的 `@lukeed/uuid`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,9 @@
       "name": "sex-consent-app",
       "version": "1.0.0",
       "dependencies": {
+        "@lukeed/uuid": "^2.0.1",
         "autoprefixer": "^10.4.17",
-        "daisyui": "3.9.4",
+        "daisyui": "^3.9.4",
         "html2canvas": "^1.4.1",
         "jspdf": "^2.5.1",
         "next": "^14.1.0",
@@ -17,15 +18,13 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.50.1",
-        "tailwindcss": "^3.4.1",
-        "uuid": "^9.0.1"
+        "tailwindcss": "^3.4.1"
       },
       "devDependencies": {
         "@types/html2canvas": "^1.0.0",
         "@types/node": "^20.11.19",
         "@types/react": "^18.2.57",
         "@types/react-dom": "^18.2.19",
-        "@types/uuid": "^9.0.8",
         "typescript": "^5.3.3"
       }
     },
@@ -116,6 +115,27 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lukeed/uuid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/csprng": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@next/env": {
@@ -384,13 +404,6 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
-    },
-    "node_modules/@types/uuid": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmmirror.com/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "6.1.0",
@@ -2152,19 +2165,6 @@
       "license": "MIT",
       "dependencies": {
         "base64-arraybuffer": "^1.0.2"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmmirror.com/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@lukeed/uuid": "^2.0.1",
     "autoprefixer": "^10.4.17",
     "daisyui": "^3.9.4",
     "html2canvas": "^1.4.1",
@@ -17,15 +18,13 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.50.1",
-    "tailwindcss": "^3.4.1",
-    "uuid": "^9.0.1"
+    "tailwindcss": "^3.4.1"
   },
   "devDependencies": {
     "@types/html2canvas": "^1.0.0",
     "@types/node": "^20.11.19",
     "@types/react": "^18.2.57",
     "@types/react-dom": "^18.2.19",
-    "@types/uuid": "^9.0.8",
     "typescript": "^5.3.3"
   }
 }

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useForm, SubmitHandler } from "react-hook-form";
-import { v4 as uuidv4 } from "uuid";
+import { v4 as uuidv4 } from "@lukeed/uuid";
 import Link from "next/link";
 
 // 定义协议表单数据类型


### PR DESCRIPTION
Replace `uuid` with `@lukeed/uuid`, which has the size of 231 Bytes yet is 6x faster.

See sizes and benchmark at https://www.npmjs.com/package/@lukeed/uuid